### PR TITLE
Fixed issue with duplicate key for styled cards in Language Home

### DIFF
--- a/client/.expo/settings.json
+++ b/client/.expo/settings.json
@@ -1,5 +1,5 @@
 {
-  "hostType": "tunnel",
+  "hostType": "lan",
   "lanType": "ip",
   "dev": true,
   "minify": false,

--- a/client/src/components/LanguageHome/LanguageHome.js
+++ b/client/src/components/LanguageHome/LanguageHome.js
@@ -170,7 +170,7 @@ const LanguageHome = ({
           >
             {renderData.map((element) => (
               <StyledCard
-                key={`${element.name}${element.body}`}
+                key={element._id}
                 titleText={element.body}
                 bodyText={element.name}
                 imageURI={element.imageURI}
@@ -260,7 +260,7 @@ const LanguageHome = ({
         >
           {renderData.map((element, index) => (
             <StyledCard
-              key={`${element.name}${element.body}`}
+              key={element._id}
               leftIcon={<NumberBox number={index + 1} />}
               titleText={element.name}
               bodyText={element.body}

--- a/client/src/components/LanguageHome/LanguageHome.js
+++ b/client/src/components/LanguageHome/LanguageHome.js
@@ -60,9 +60,8 @@ const LanguageHome = ({
     setRenderData(data)
   }, [data])
 
-  const {
-    currentCourseId, currentUnitId, currentLessonId, lessonData,
-  } = useSelector((state) => state.language)
+  const { currentCourseId, currentUnitId, currentLessonId, lessonData } =
+    useSelector((state) => state.language)
 
   const getAudio = async (vocabId) => {
     await errorWrap(async () => {
@@ -150,13 +149,13 @@ const LanguageHome = ({
             title="Add New"
             variant="manage"
             fontSize={15}
-            rightIcon={(
+            rightIcon={
               <MaterialCommunityIcons
                 name="plus-circle"
                 color={colors.red.dark}
                 size={20}
               />
-            )}
+            }
             onPress={buttonCallback}
           />
         </View>
@@ -178,14 +177,14 @@ const LanguageHome = ({
                 volumeIconCallback={() => getAudio(element._id)}
                 width={width * 0.97}
                 height={element.imageURI === '' ? 75 : 100}
-                rightIcon={(
+                rightIcon={
                   <MaterialCommunityIcons
                     name="pencil"
                     color="black"
                     size={20}
                     onPress={() => nextPageCallback(element)}
                   />
-                )}
+                }
               />
             ))}
           </View>
@@ -240,13 +239,13 @@ const LanguageHome = ({
           title={buttonText}
           variant="manage"
           fontSize={15}
-          rightIcon={(
+          rightIcon={
             <MaterialCommunityIcons
               name={rightIconName}
               color={colors.red.dark}
               size={20}
             />
-          )}
+          }
           onPress={buttonCallback}
         />
       </View>
@@ -267,14 +266,14 @@ const LanguageHome = ({
               width={width * 0.97}
               height={75}
               indicatorType={element.indicatorType}
-              rightIcon={(
+              rightIcon={
                 <MaterialCommunityIcons
                   name="pencil"
                   color="black"
                   size={20}
                   onPress={() => nextPageCallback(element)}
                 />
-              )}
+              }
             />
           ))}
         </View>

--- a/client/src/theme/colors.js
+++ b/client/src/theme/colors.js
@@ -21,7 +21,7 @@ const colors = {
     dark: '#C0D152', // 500 opacity
   },
   gray: {
-    semi_transparent: '#00000020', 
+    semi_transparent: '#00000020',
     light: '#EFEFEF', // 100 opacity
     medium_light: '#F4F4F4', // 300 opacity
     medium: '#A4A4A4', // 500 opacity


### PR DESCRIPTION
## Status:

:rocket: Ready

## Description
Fixes #181 

We were originally using `key={${element.name}${element.body}}` as the key value for the cards, which could result in conflicts/duplicates in the case where the name and body of the elements are the same

## Screenshots
![IMG_8686](https://user-images.githubusercontent.com/21271918/194455901-f447f657-70c8-4ebb-9ba6-a472938e42e5.PNG)
