### PR TITLE
Move Create Unit/Lessons Button to the Home Pages

### DIFF
--- a/client/src/components/LanguageHome/LanguageHome.js
+++ b/client/src/components/LanguageHome/LanguageHome.js
@@ -4,7 +4,7 @@ import { colors } from 'theme'
 import PropTypes from 'prop-types'
 import { ScrollView, Text } from 'native-base'
 import StyledButton from 'components/StyledButton'
-import { MaterialCommunityIcons } from '@expo/vector-icons'
+import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons'
 import StyledCard from 'components/StyledCard'
 import NumberBox from 'components/NumberBox'
 import { downloadAudioFile } from 'api'
@@ -44,10 +44,12 @@ const LanguageHome = ({
   languageDescription,
   lessonDescription,
   valueName,
-  buttonText,
-  rightIconName,
+  manageButtonText,
+  addButtonText,
+  manageIconName,
   buttonCallback,
   nextPageCallback,
+  addCallback,
   data,
 }) => {
   const errorWrap = useErrorWrap()
@@ -237,12 +239,12 @@ const LanguageHome = ({
           {renderData.length} {valueName}
         </Text>
         <StyledButton
-          title={buttonText}
+          title={manageButtonText}
           variant="manage"
           fontSize={15}
           rightIcon={(
             <MaterialCommunityIcons
-              name={rightIconName}
+              name={manageIconName}
               color={colors.red.dark}
               size={20}
             />
@@ -279,6 +281,19 @@ const LanguageHome = ({
           ))}
         </View>
       </ScrollView>
+
+      <View style={{ position: 'absolute', bottom: '5%', right: '5%' }}>
+        <StyledButton
+          title={addButtonText}
+          variant="small"
+          fontSize="20"
+          leftIcon={
+            <AntDesign name="pluscircle" size={20} color={colors.red.dark} />
+          }
+          shadow
+          onPress={addCallback}
+        />
+      </View>
     </>
   )
 }
@@ -290,10 +305,12 @@ LanguageHome.propTypes = {
   languageDescription: PropTypes.string,
   lessonDescription: PropTypes.string,
   valueName: PropTypes.string,
-  buttonText: PropTypes.string,
-  rightIconName: PropTypes.string,
+  manageButtonText: PropTypes.string,
+  addButtonText: PropTypes.string,
+  manageIconName: PropTypes.string,
   buttonCallback: PropTypes.func,
   nextPageCallback: PropTypes.func,
+  addCallback: PropTypes.func,
   data: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
 }
 
@@ -304,10 +321,12 @@ LanguageHome.defaultProps = {
   languageDescription: '',
   lessonDescription: 'You currently have not set a description.',
   valueName: '',
-  buttonText: '',
-  rightIconName: '',
+  manageButtonText: '',
+  addButtonText: '',
+  manageIconName: '',
   buttonCallback: () => {},
   nextPageCallback: () => {},
+  addCallback: () => {},
   data: [],
 }
 

--- a/client/src/components/ManageView/ManageView.js
+++ b/client/src/components/ManageView/ManageView.js
@@ -68,9 +68,7 @@ const ManageView = ({
   unselectedTitleText,
   selectedBodyText,
   unselectedBodyText,
-  addText,
   saveCallback,
-  addCallback,
   initialSelectedData,
   initialUnselectedData,
   playAudio,
@@ -301,19 +299,6 @@ const ManageView = ({
             <Text fontFamily="heading" fontWeight="regular" fontSize="xl">
               {selectedTitleText}
             </Text>
-            <StyledButton
-              title={addText}
-              variant="small"
-              fontSize="md"
-              rightIcon={(
-                <AntDesign
-                  name="pluscircle"
-                  size={18}
-                  color={colors.red.dark}
-                />
-              )}
-              onPress={addCallback}
-            />
           </View>
           <Text
             fontFamily="body"
@@ -372,9 +357,7 @@ ManageView.propTypes = {
   unselectedTitleText: PropTypes.string,
   selectedBodyText: PropTypes.string,
   unselectedBodyText: PropTypes.string,
-  addText: PropTypes.string,
   saveCallback: PropTypes.func,
-  addCallback: PropTypes.func,
   initialSelectedData: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
   initialUnselectedData: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
   playAudio: PropTypes.func,
@@ -389,9 +372,7 @@ ManageView.defaultProps = {
   unselectedTitleText: '',
   selectedBodyText: '',
   unselectedBodyText: '',
-  addText: '',
   saveCallback: () => {},
-  addCallback: () => {},
   initialSelectedData: [],
   initialUnselectedData: [],
   playAudio: () => {},

--- a/client/src/components/StyledButton/StyledButton.js
+++ b/client/src/components/StyledButton/StyledButton.js
@@ -10,6 +10,7 @@ const StyledButton = ({
   leftIcon,
   rightIcon,
   fontSize,
+  shadow,
   style,
   isDisabled,
 }) => (
@@ -19,6 +20,7 @@ const StyledButton = ({
     _text={{ fontSize }}
     leftIcon={leftIcon}
     endIcon={rightIcon}
+    shadow={shadow === true ? 4 : -1}
     style={style}
     isDisabled={isDisabled}
   >
@@ -33,6 +35,7 @@ StyledButton.propTypes = {
   leftIcon: PropTypes.element,
   rightIcon: PropTypes.element,
   fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  shadow: PropTypes.bool,
   style: ViewPropTypes.style,
   isDisabled: PropTypes.bool,
 }
@@ -44,6 +47,7 @@ StyledButton.defaultProps = {
   rightIcon: null,
   onPress: () => {},
   fontSize: 'lg',
+  shadow: false,
   style: {},
   isDisabled: false,
 }

--- a/client/src/pages/CourseHome/CourseHome.js
+++ b/client/src/pages/CourseHome/CourseHome.js
@@ -59,15 +59,24 @@ const CourseHome = ({ navigation, courseDescription, courseName }) => {
     navigation.navigate('UnitHome')
   }
 
+  /**
+   * Navigates to the Add Unit Page
+   */
+  const navigateToAdd = () => {
+    navigation.navigate('Modal', { screen: 'CreateUnit' })
+  }
+
   return (
     <LanguageHome
       languageName={courseName}
       languageDescription={courseDescription}
       valueName="Units"
-      buttonText="Manage Units"
-      rightIconName="pencil"
+      manageButtonText="Manage Units"
+      addButtonText="Add Unit"
+      manageIconName="cog"
       buttonCallback={navigateToManage}
       nextPageCallback={goToNextPage}
+      addCallback={navigateToAdd}
       data={data}
     />
   )

--- a/client/src/pages/LessonHome/LessonHome.js
+++ b/client/src/pages/LessonHome/LessonHome.js
@@ -142,7 +142,7 @@ const LessonHome = ({ navigation }) => {
       isLessonHome
       lessonDescription={lessonDescription}
       valueName="Lessons"
-      rightIconName="plus-circle"
+      manageIconName="plus-circle"
       buttonCallback={navigateTo}
       nextPageCallback={goToNextPage}
       data={data}

--- a/client/src/pages/ManageLessons/ManageLessons.js
+++ b/client/src/pages/ManageLessons/ManageLessons.js
@@ -93,13 +93,6 @@ const ManageLessons = ({ navigation }) => {
     )
   }
 
-  /**
-   * Navigates to the Create Lesson modal
-   */
-  const add = () => {
-    navigation.navigate('Modal', { screen: 'CreateLesson' })
-  }
-
   return (
     <ManageView
       navigation={navigation}
@@ -107,9 +100,7 @@ const ManageLessons = ({ navigation }) => {
       unselectedTitleText="Unselected Lessons"
       selectedBodyText="These lessons will be available to your students. Drag them around to reorder them."
       unselectedBodyText="These lessons are not included in your course. You can still continue to edit them."
-      addText="Create Lessons"
       saveCallback={saveChanges}
-      addCallback={add}
       initialSelectedData={selected}
       initialUnselectedData={unselected}
     />

--- a/client/src/pages/ManageUnits/ManageUnits.js
+++ b/client/src/pages/ManageUnits/ManageUnits.js
@@ -94,13 +94,6 @@ const ManageUnits = ({ navigation }) => {
     )
   }
 
-  /**
-   * Navigates to the Create Unit modal
-   */
-  const add = () => {
-    navigation.navigate('Modal', { screen: 'CreateUnit' })
-  }
-
   return (
     <ManageView
       navigation={navigation}
@@ -108,9 +101,7 @@ const ManageUnits = ({ navigation }) => {
       unselectedTitleText="Unselected Units"
       selectedBodyText="These units will be available to your students. Drag them around to reorder them."
       unselectedBodyText="These units are not included in your course. You can still continue to edit them."
-      addText="Create Unit"
       saveCallback={saveChanges}
-      addCallback={add}
       initialSelectedData={selected}
       initialUnselectedData={unselected}
     />

--- a/client/src/pages/UnitHome/UnitHome.js
+++ b/client/src/pages/UnitHome/UnitHome.js
@@ -110,14 +110,23 @@ const UnitHome = ({ navigation }) => {
     navigation.navigate('LessonHome')
   }
 
+  /**
+   * Navigates to the Add Lesson Page
+   */
+  const navigateToAdd = () => {
+    navigation.navigate('Modal', { screen: 'CreateLesson' })
+  }
+
   return (
     <LanguageHome
       languageDescription={unitDescription}
       valueName="Lessons"
-      buttonText="Manage Lessons"
-      rightIconName="pencil"
+      manageButtonText="Manage Lessons"
+      addButtonText="Add Lesson"
+      manageIconName="cog"
       buttonCallback={navigateToManage}
       nextPageCallback={goToNextPage}
+      addCallback={navigateToAdd}
       data={data}
     />
   )

--- a/client/src/theme/nativebase.js
+++ b/client/src/theme/nativebase.js
@@ -101,8 +101,6 @@ const theme = extendTheme({
         },
         small: {
           bg: 'red.light',
-          borderColor: 'white.dark',
-          borderWidth: 2,
           px: 0,
           py: 4,
           _text: {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Moves add unit button from course settings to the course home page; moves add lesson button from unit settings page to the unit home page. Also adds a shadow to the add button based on the figma. Removes unnecessary code for the add button from the respective settings pages. 

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #231.

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->