### PR TITLE
Replace edit button with chevron

### DIFF
--- a/client/.expo/packager-info.json
+++ b/client/.expo/packager-info.json
@@ -1,7 +1,7 @@
 {
   "devToolsPort": 19002,
   "expoServerPort": null,
-  "packagerPort": null,
+  "packagerPort": 19000,
   "packagerPid": null,
   "expoServerNgrokUrl": null,
   "packagerNgrokUrl": null,

--- a/client/.expo/settings.json
+++ b/client/.expo/settings.json
@@ -1,5 +1,5 @@
 {
-  "hostType": "tunnel",
+  "hostType": "lan",
   "lanType": "ip",
   "dev": true,
   "minify": false,

--- a/client/src/components/LanguageHome/LanguageHome.js
+++ b/client/src/components/LanguageHome/LanguageHome.js
@@ -215,33 +215,29 @@ const LanguageHome = ({
           }}
         >
           {renderData.map((element, index) => (
-            <Pressable onPress={() => nextPageCallback(element)} key={element._id}
+            <Pressable
+              onPress={() => nextPageCallback(element)}
+              key={element._id}
             >
-              {({
-                isHovered,
-                isFocused,
-                isPressed
-              }) => {
-                return (
-                  <StyledCard
-                    key={element._id}
-                    leftIcon={<NumberBox number={index + 1} />}
-                    titleText={element.name}
-                    bodyText={element.body}
-                    width={width * 0.97}
-                    height={75}
-                    indicatorType={element.indicatorType}
-                    rightIcon={(
-                      <MaterialCommunityIcons
-                        name="chevron-right"
-                        color="black"
-                        size={40}
-                      />
-                    )}
-                    isPressed={isPressed}
-                  />
-                );
-              }}
+              {({ isPressed }) => (
+                <StyledCard
+                  key={element._id}
+                  leftIcon={<NumberBox number={index + 1} />}
+                  titleText={element.name}
+                  bodyText={element.body}
+                  width={width * 0.97}
+                  height={75}
+                  indicatorType={element.indicatorType}
+                  rightIcon={(
+                    <MaterialCommunityIcons
+                      name="chevron-right"
+                      color="black"
+                      size={40}
+                    />
+                  )}
+                  isPressed={isPressed}
+                />
+              )}
             </Pressable>
           ))}
         </View>
@@ -289,9 +285,9 @@ LanguageHome.defaultProps = {
   manageButtonText: '',
   addButtonText: '',
   manageIconName: '',
-  buttonCallback: () => { },
-  nextPageCallback: () => { },
-  addCallback: () => { },
+  buttonCallback: () => {},
+  nextPageCallback: () => {},
+  addCallback: () => {},
   data: [],
 }
 

--- a/client/src/components/LanguageHome/LanguageHome.js
+++ b/client/src/components/LanguageHome/LanguageHome.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { StyleSheet, View, Dimensions } from 'react-native'
 import { colors } from 'theme'
 import PropTypes from 'prop-types'
-import { ScrollView, Text } from 'native-base'
+import { ScrollView, Text, Pressable } from 'native-base'
 import StyledButton from 'components/StyledButton'
 import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons'
 import StyledCard from 'components/StyledCard'
@@ -215,23 +215,34 @@ const LanguageHome = ({
           }}
         >
           {renderData.map((element, index) => (
-            <StyledCard
-              key={element._id}
-              leftIcon={<NumberBox number={index + 1} />}
-              titleText={element.name}
-              bodyText={element.body}
-              width={width * 0.97}
-              height={75}
-              indicatorType={element.indicatorType}
-              rightIcon={(
-                <MaterialCommunityIcons
-                  name="pencil"
-                  color="black"
-                  size={20}
-                  onPress={() => nextPageCallback(element)}
-                />
-              )}
-            />
+            <Pressable onPress={() => nextPageCallback(element)} key={element._id}
+            >
+              {({
+                isHovered,
+                isFocused,
+                isPressed
+              }) => {
+                return (
+                  <StyledCard
+                    key={element._id}
+                    leftIcon={<NumberBox number={index + 1} />}
+                    titleText={element.name}
+                    bodyText={element.body}
+                    width={width * 0.97}
+                    height={75}
+                    indicatorType={element.indicatorType}
+                    rightIcon={(
+                      <MaterialCommunityIcons
+                        name="chevron-right"
+                        color="black"
+                        size={40}
+                      />
+                    )}
+                    isPressed={isPressed}
+                  />
+                );
+              }}
+            </Pressable>
           ))}
         </View>
       </ScrollView>
@@ -278,9 +289,9 @@ LanguageHome.defaultProps = {
   manageButtonText: '',
   addButtonText: '',
   manageIconName: '',
-  buttonCallback: () => {},
-  nextPageCallback: () => {},
-  addCallback: () => {},
+  buttonCallback: () => { },
+  nextPageCallback: () => { },
+  addCallback: () => { },
   data: [],
 }
 

--- a/client/src/components/StyledCard/StyledCard.js
+++ b/client/src/components/StyledCard/StyledCard.js
@@ -65,6 +65,7 @@ const StyledCard = ({
   volumeIconCallback,
   width,
   height,
+  isPressed
 }) => {
   const generateLeftIcon = leftIcon ? (
     <Box style={styles.leftIcon}>{leftIcon}</Box>
@@ -112,7 +113,7 @@ const StyledCard = ({
       height={height}
       style={styles.root}
       borderRadius="md"
-      bg="white.dark"
+      bg={isPressed ? colors.gray.medium_light : colors.white.dark}
     >
       <Box px="2" style={styles.left}>
         {generateImage}
@@ -161,7 +162,7 @@ StyledCard.defaultProps = {
   indicatorType: INDICATOR_TYPES.NONE,
   imageURI: '',
   showVolumeIcon: false,
-  volumeIconCallback: () => {},
+  volumeIconCallback: () => { },
   width: 100,
   height: 70,
 }

--- a/client/src/components/StyledCard/StyledCard.js
+++ b/client/src/components/StyledCard/StyledCard.js
@@ -65,7 +65,7 @@ const StyledCard = ({
   volumeIconCallback,
   width,
   height,
-  isPressed
+  isPressed,
 }) => {
   const generateLeftIcon = leftIcon ? (
     <Box style={styles.leftIcon}>{leftIcon}</Box>
@@ -152,6 +152,7 @@ StyledCard.propTypes = {
   volumeIconCallback: PropTypes.func,
   width: PropTypes.number,
   height: PropTypes.number,
+  isPressed: PropTypes.bool,
 }
 
 StyledCard.defaultProps = {
@@ -162,9 +163,10 @@ StyledCard.defaultProps = {
   indicatorType: INDICATOR_TYPES.NONE,
   imageURI: '',
   showVolumeIcon: false,
-  volumeIconCallback: () => { },
+  volumeIconCallback: () => {},
   width: 100,
   height: 70,
+  isPressed: false,
 }
 
 export default StyledCard


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Adds chevron icon in place of the previous pencil icon for course and unit. The whole styled card is now pressable, and the background color of the card darkens when pressed. 

Fixes #252.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #<number>

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->