### PR TITLE
Removed iOS and Android Client IDs

### DIFF
--- a/api/src/middleware/authentication.js
+++ b/api/src/middleware/authentication.js
@@ -66,6 +66,8 @@ const getUserByIDToken = async (idToken) => {
     }
     return null;
   } catch (error) {
+    console.log("Error :(");
+    console.log(error);
     return null;
   }
 };

--- a/api/src/middleware/authentication.js
+++ b/api/src/middleware/authentication.js
@@ -66,8 +66,7 @@ const getUserByIDToken = async (idToken) => {
     }
     return null;
   } catch (error) {
-    console.log("Error :(");
-    console.log(error);
+    console.error('Error during Google Auth ID Token Verification: ', error);
     return null;
   }
 };

--- a/client/app.config.js
+++ b/client/app.config.js
@@ -3,14 +3,10 @@ export default ({ config }) => {
   return {
     ...config,
     extra: {
-      // apiURL: '', // Comment out if you want to connect to the local api
+      apiURL: '', // Comment out if you want to connect to the local api
       apiDevelopmentPort: 3000,
       expoClientId:
-        '1534417123-rirmc8ql9i0jqrqchojsl2plf5c102j6.apps.googleusercontent.com',
-      iosClientId:
-        '1534417123-ghavvlkgsmuc7nmu8o9d28se4e9s9cd1.apps.googleusercontent.com',
-      androidClientId:
-        '1534417123-gmng6jq2mvii7oa2gibcovt0cqpqk6fn.apps.googleusercontent.com',
+        '1534417123-kdiotii3qddj0kumdchnrv870u9c0ihl.apps.googleusercontent.com',
     },
   }
 }


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

After the switch from expo-google-auth-app to Expo AuthSession in #273, the Android and iOS Google Auth Client IDs are no longer needed. This PR removes them from the client-side.

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->