### PR TITLE
Fix style button warnings

### DIFF
--- a/client/src/pages/CourseSettings/CourseSettings.js
+++ b/client/src/pages/CourseSettings/CourseSettings.js
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
   },
   delete: {
     position: 'absolute',
-    bottom: 0,
+    bottom: '0%',
     width: '90%',
   },
 })

--- a/client/src/pages/VocabDrawer/VocabDrawer.js
+++ b/client/src/pages/VocabDrawer/VocabDrawer.js
@@ -485,7 +485,7 @@ const VocabDrawer = ({ navigation }) => {
         title={i18n.t('actions.addImage')}
         variant="image_picker"
         onPress={selectImage}
-        style={{ height: 100 }}
+        style={{ height: '10%' }}
       />
     )
   }


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready
<!--

:construction: In development
:no_entry_sign: Do not merge
-->

## Description

The CourseSettings delete button had InvalidProp warnings and there was a similar issue for the add image button on the VocabDrawer page and this fixes both of those.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->