### PR TITLE
Stricter load auth check on app open + Documentation for exchangeAuthCode

### DIFF
--- a/client/src/navigator/Navigator.js
+++ b/client/src/navigator/Navigator.js
@@ -5,7 +5,7 @@ import { authenticate } from 'slices/auth.slice'
 import { createStackNavigator } from '@react-navigation/stack'
 import DrawerNavigator from './Drawer'
 import { AuthNavigator, ModalNavigator } from './Stacks'
-import { getUser } from '../api/api'
+import { getUser } from 'api'
 
 const RootStack = createStackNavigator()
 const Navigator = () => {
@@ -17,7 +17,7 @@ const Navigator = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    const loadUserAuth = async () => {
+    const loadUserAuth = () => {
       getUser()
         .then(() => {
           dispatch(authenticate({ loggedIn: true }))

--- a/client/src/navigator/Navigator.js
+++ b/client/src/navigator/Navigator.js
@@ -17,7 +17,7 @@ const Navigator = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    const loadAuthFromPersistentStorage = async () => {
+    const loadUserAuth = async () => {
       getUser()
         .then(() => {
           dispatch(authenticate({ loggedIn: true }))
@@ -27,7 +27,7 @@ const Navigator = () => {
         })
     }
 
-    loadAuthFromPersistentStorage()
+    loadUserAuth()
   }, [])
 
   const { loggedIn } = useSelector((state) => state.auth)

--- a/client/src/navigator/Navigator.js
+++ b/client/src/navigator/Navigator.js
@@ -2,10 +2,10 @@ import React, { useEffect } from 'react'
 import { NavigationContainer } from '@react-navigation/native'
 import { useSelector, useDispatch } from 'react-redux'
 import { authenticate } from 'slices/auth.slice'
-import { loadUserIDToken } from 'utils/auth'
 import { createStackNavigator } from '@react-navigation/stack'
 import DrawerNavigator from './Drawer'
 import { AuthNavigator, ModalNavigator } from './Stacks'
+import { getUser } from '../api/api'
 
 const RootStack = createStackNavigator()
 const Navigator = () => {
@@ -18,12 +18,13 @@ const Navigator = () => {
 
   useEffect(() => {
     const loadAuthFromPersistentStorage = async () => {
-      const idToken = await loadUserIDToken()
-      if (idToken != null) {
-        dispatch(authenticate({ loggedIn: true }))
-      } else {
-        dispatch(authenticate({ loggedIn: false }))
-      }
+      getUser()
+        .then(() => {
+          dispatch(authenticate({ loggedIn: true }))
+        })
+        .catch(() => {
+          dispatch(authenticate({ loggedIn: false }))
+        })
     }
 
     loadAuthFromPersistentStorage()

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -146,6 +146,21 @@ export const removeUserClientId = async () => {
   }
 }
 
+/**
+ * @typedef {Object} ExchangeResponse
+ * @property {boolean} success - Whether exchange auth code was successful
+ * @property {String} message - Response Message
+ * @property {String} idToken - idToken exchanged from authorization code
+ */
+
+/**
+ * Exchanges the authorization_code for idToken and refreshToken
+ * @param {String} code
+ * @param {String} clientId
+ * @param {String} clientSecret
+ * @param {String} codeVerifier
+ * @returns {ExchangeResponse} Exchange response
+ */
 export const exchangeAuthCode = async (
   code,
   clientId,
@@ -166,6 +181,7 @@ export const exchangeAuthCode = async (
   .then(async (authentication) => {
     const { idToken, refreshToken } = authentication
     if (idToken !== null && refreshToken !== null) {
+      // id token has to be saved before api calls are made, the other save's can be async
       await saveUserIDToken(idToken)
       saveUserRefreshToken(refreshToken)
       saveUserClientId(clientId)


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready


## Description
Previously loadAuth from local storage just simply checked if the user has an `idToken` in store, which sometimes isn't exactly correct since we could be switching environments(dev to prod, prod to dev, etc.) where the `clientId` could be different and the `idToken` is no longer valid for the new environment. Thus, we want to enforce a better way to check strictly if the user has already been authenticated. The easiest way to do this is to simply send our backend(which has the authentication middleware) a request and see if it succeeds.

Added some documentation for new `exchangeAuthCode` function

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->